### PR TITLE
Correctly handle empty bloom filters, avoid infinite loop

### DIFF
--- a/deterministic-bloom/src/common.rs
+++ b/deterministic-bloom/src/common.rs
@@ -73,6 +73,11 @@ impl<T: AsRef<[u8]>> Iterator for HashIndexIterator<'_, T> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.bit_size == 0 {
+            // This avoids an infinite loop in rejection sampling.
+            return None;
+        }
+
         let bit_size_po2 = self.bit_size.next_power_of_two();
         loop {
             let hash = xxh3::xxh3_64_with_seed(self.item.as_ref(), self.index) as usize;

--- a/deterministic-bloom/src/common.rs
+++ b/deterministic-bloom/src/common.rs
@@ -196,6 +196,17 @@ impl BloomParams {
 }
 
 #[cfg(test)]
+mod tests {
+    use super::HashIndexIterator;
+
+    #[test]
+    fn test_zero_bit_size() {
+        let mut iterator = HashIndexIterator::new(&[1, 2, 3], 0);
+        assert_eq!(iterator.next(), None);
+    }
+}
+
+#[cfg(test)]
 mod proptests {
     use super::BloomParams;
     use proptest::prop_assert;

--- a/deterministic-bloom/src/runtime_size.rs
+++ b/deterministic-bloom/src/runtime_size.rs
@@ -234,10 +234,6 @@ impl BloomFilter {
     /// assert!(filter.contains(&106u32.to_le_bytes()));
     /// ```
     pub fn contains(&self, item: &impl AsRef<[u8]>) -> bool {
-        if self.bytes.len() == 0 {
-            return false;
-        }
-
         for i in self.hash_indices(item) {
             if !self.bytes.view_bits::<Lsb0>()[i] {
                 return false;
@@ -291,7 +287,8 @@ mod tests {
     #[test]
     fn empty_bloom_filter() {
         let filter = BloomFilter::new_with(3, Box::new([]));
-        assert!(!filter.contains(&[1, 2, 3]));
+        // Technically an empty bloom "contains" anything, since everything is a false positive.
+        assert!(filter.contains(&[1, 2, 3]));
     }
 }
 

--- a/deterministic-bloom/src/runtime_size.rs
+++ b/deterministic-bloom/src/runtime_size.rs
@@ -234,6 +234,10 @@ impl BloomFilter {
     /// assert!(filter.contains(&106u32.to_le_bytes()));
     /// ```
     pub fn contains(&self, item: &impl AsRef<[u8]>) -> bool {
+        if self.bytes.len() == 0 {
+            return false;
+        }
+
         for i in self.hash_indices(item) {
             if !self.bytes.view_bits::<Lsb0>()[i] {
                 return false;
@@ -282,6 +286,12 @@ mod tests {
         assert!(deserialized.contains(b"Hello"));
         assert!(!deserialized.contains(b"abc"));
         assert_eq!(deserialized, filter);
+    }
+
+    #[test]
+    fn empty_bloom_filter() {
+        let filter = BloomFilter::new_with(3, Box::new([]));
+        assert!(!filter.contains(&[1, 2, 3]));
     }
 }
 

--- a/deterministic-bloom/src/runtime_size.rs
+++ b/deterministic-bloom/src/runtime_size.rs
@@ -335,6 +335,6 @@ mod proptests {
 
         let computed_fpr = false_positives as f64 / measurements as f64;
         // The actual FPR should be pretty close
-        prop_assert!((computed_fpr - fpr).abs() < 1e-3);
+        prop_assert!((computed_fpr - fpr).abs() < 1.5e-3);
     }
 }


### PR DESCRIPTION
`HashIndexIterator` used to loop infinitely when `bit_size` was 0, because it wouldn't be able to generate a random index that's `< 0` (fair enough).

Now it simply exists instantly if `bit_size == 0`.

Also added a test case for empty blooms. They "technically" contain everything as a false positive. I opted for that, rather than "an empty bloom contains nothing", since that keeps the invariant that if you `.insert` something into a bloom filter, it will *always* be `contain`ed.